### PR TITLE
Describe always fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
   - ruby-head
 script: 'bundle exec rake'

--- a/lib/project_version_tag.rb
+++ b/lib/project_version_tag.rb
@@ -23,7 +23,7 @@ module Jekyll
     end
 
     def git_describe
-      tagged_version = %x{ git describe --tags }
+      tagged_version = %x{ git describe --tags --always }
 
       if command_succeeded?
         tagged_version

--- a/spec/project_version_tag_spec.rb
+++ b/spec/project_version_tag_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Jekyll::ProjectVersionTag do
   let(:git_test_command) { 'git rev-parse' }
-  let(:git_tag_command) { ' git describe --tags ' }
+  let(:git_tag_command) { ' git describe --tags --always ' }
   let(:git_last_commit_command) { ' git rev-parse --short HEAD ' }
   let(:context) { nil }
 
@@ -26,7 +26,7 @@ describe Jekyll::ProjectVersionTag do
     before do
       allow(subject).to receive(:`).with(git_last_commit_command).and_return(nil)
       allow(subject).to receive(:`).with(git_tag_command).and_return(nil)
-      allow(subject).to receive(:command_succeeded?).and_return(true) # argh
+      allow(subject).to receive(:command_succeeded?).and_return(true)
     end
 
     it 'returns an unable to read project message' do
@@ -38,7 +38,7 @@ describe Jekyll::ProjectVersionTag do
     before do
       allow(subject).to receive(:`).with(git_last_commit_command).and_return('abcdefg')
       allow(subject).to receive(:`).with(git_tag_command).and_return(nil)
-      allow(subject).to receive(:command_succeeded?).and_return(true) # argh
+      allow(subject).to receive(:command_succeeded?).and_return(true)
     end
 
     it 'returns the last commit sha' do
@@ -49,7 +49,7 @@ describe Jekyll::ProjectVersionTag do
   context 'given a git repository with a commit and a tag' do
     before do
       allow(subject).to receive(:`).with(git_tag_command).and_return('v1.0.0')
-      allow(subject).to receive(:command_succeeded?).and_return(true) # argh
+      allow(subject).to receive(:command_succeeded?).and_return(true)
     end
 
     it 'returns the last commit sha' do


### PR DESCRIPTION
Use `git describe --always` to avoid an error if there are no tags.